### PR TITLE
Add loader to button

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -32,3 +32,18 @@ Disabled.args = {
   disabled: true,
   label: "Button",
 };
+
+export const Loading = Template.bind({});
+Loading.args = {
+  variant: "primary",
+  isLoading: true,
+  label: "This should not be shown"
+};
+
+export const LoadingWithLabel = Template.bind({});
+LoadingWithLabel.args = {
+  variant: "primary",
+  isLoading: true,
+  loadingLabel: "Loading...",
+  label: "This should not be shown"
+};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactElement } from "react";
 import "./button.css";
 import "../global.styles.css";
 export interface ButtonProps {
@@ -23,6 +23,14 @@ export interface ButtonProps {
    */
   disabled?: boolean;
   /**
+   * Is this button in loading state? 
+   */
+  isLoading?: boolean;
+  /**
+   * Button contents if in loading state
+   */
+  loadingLabel?: string;
+  /**
    * Optional click handler
    */
   onClick?: () => void;
@@ -36,8 +44,13 @@ const Button = ({
   bgColor,
   label,
   labelColor,
+  isLoading = false,
   ...props
 }: ButtonProps) => {
+  if (isLoading) {
+    props.disabled = true;
+  }
+
   return (
     <button
       type="button"
@@ -45,7 +58,17 @@ const Button = ({
       style={{ color: labelColor, backgroundColor: bgColor }}
       {...props}
     >
-      {label}
+      {
+        isLoading ? 
+        (
+          <div style={{display: "flex", alignItems: "center", fontSize: "1em", lineHeight: "normal"}}>
+            <div className="loader" style={props.loadingLabel ? {marginRight: "0.5rem"} : {fontSize: "1rem"}}/>
+            {props.loadingLabel}
+          </div>
+        ) : (
+          label
+        )
+      }
     </button>
   );
 };

--- a/src/components/Button/button.css
+++ b/src/components/Button/button.css
@@ -27,3 +27,18 @@ button[disabled] {
   opacity: 0.5;
   cursor: default;
 }
+
+.loader {
+  border: 0.125rem solid #f3f3f3; /* Light grey */
+  border-top: 0.125rem solid #3498db; /* Blue */
+  border-right: 0.125rem solid #3498db; /* Blue */
+  border-radius: 50%;
+  width: 0.5rem;
+  height: 0.5rem;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
New props added: 
- isLoading: boolean
- loadingLabel: label to be shown when isLoading == true

Idea of having loadingLabel is so that user side only needs to flip isLoading to either true/false; button component will auto-handle what label to show the user i.e. either label or loadingLabel. 

![image](https://user-images.githubusercontent.com/41280211/155869532-602d5ecd-2250-42f8-8560-89c84aece74f.png)
